### PR TITLE
hotfix: nextResponse s3주소 반환하지 않는 안전한 방식으로 변경 응답형식을 객체로 변환

### DIFF
--- a/app/api/testone/route.ts
+++ b/app/api/testone/route.ts
@@ -103,7 +103,12 @@ export async function POST(request: NextRequest) {
             console.log('레디스 등록됨 :', validatedData.taskId, result.url);
         }
 
-        return NextResponse.json(result);
+        const safeResponse = {
+            code: result.code,
+            message: result.message,
+        };
+        return NextResponse.json(safeResponse)
+        
     } catch (error) {
         //zod에러 발생은 클라이언트쪽에서 무언가 이상행동을 했을 가능성이 높아 400처리
         if (error instanceof z.ZodError) {


### PR DESCRIPTION
객체형식을 맞추기 위해 result.code => saferesponse {code , message} 로 변경